### PR TITLE
fix: add title min validation

### DIFF
--- a/app/Messages/Outgoing/Fields/Title.php
+++ b/app/Messages/Outgoing/Fields/Title.php
@@ -23,6 +23,7 @@ class Title extends TextQuestion
         $rules = parent::getRules();
         $validationRules = [
           'string',
+          'min:2',
           'max:150',
         ];
 


### PR DESCRIPTION
AFAIK this must solve https://github.com/ushahidi/platform/issues/4023. 

I noticed the platform is throwing an error when the title is less than 2 characters.
The title is used to build the post slug, which should be 2 or more characters. The platform client also says that the title is too short when trying yo submit one character. 