### PR TITLE
fix the repository url in the git clone in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please check the official Laravel [installation guide](https://laravel.com/docs/
 
 Clone the repository
 
-    git clone git@github.com:ushahidi/ussd-engine.git
+    git clone https://github.com/ushahidi/ussd-engine.git
 
 Switch to the repo folder
 
@@ -52,7 +52,7 @@ You can now access the server at http://localhost:8000
 
 **TL;DR command list**
 
-    git clone git@github.com:ushahidi/ussd-engine.git
+    git clone https://github.com/ushahidi/ussd-engine.git
     cd ussd-engine
     composer install
     cp .env.example .env


### PR DESCRIPTION
@Angamanga  While going through the the process of installing the bot-engine in the readme, I noticed the repo url in the ```git clone``` command was not working so this is a fix.