### PR TITLE
#96: handle default value settings for title and description

### DIFF
--- a/app/Conversations/SurveyConversation.php
+++ b/app/Conversations/SurveyConversation.php
@@ -592,9 +592,15 @@ class SurveyConversation extends Conversation
     private function askField(array $field)
     {
         $question = FieldQuestionFactory::create($field);
-        $questionScreen = new QuestionScreen($question);
 
-        $this->ask($questionScreen, $this->getFieldHandler($questionScreen));
+        // If the question should be skipped (because it has a pre-defined answer) add the answer and continue
+        if ($question->getSkipQuestion()) {
+            $this->answers[] = $question->toPayload();
+            $this->askNextField();
+        } else {
+            $questionScreen = new QuestionScreen($question);
+            $this->ask($questionScreen, $this->getFieldHandler($questionScreen));
+        }
     }
 
     /**

--- a/app/Messages/Outgoing/FieldQuestion.php
+++ b/app/Messages/Outgoing/FieldQuestion.php
@@ -18,12 +18,39 @@ abstract class FieldQuestion extends Question implements FieldQuestionInterface
      */
     protected $field;
 
+    protected $defaultAnswerValue;
+
     protected $answerValue;
+
+    protected $skipQuestion;
+
 
     public function __construct(array $field)
     {
         $this->field = $field;
+        $this->defaultAnswerValue = null;
+        $this->skipQuestion = false;
         parent::__construct($this->getTextContent());
+    }
+
+    public function setDefaultAnswerValue(string $defaultAnswerValue) {
+        $this->defaultAnswerValue = $defaultAnswerValue;
+    }
+
+    public function setSkipQuestion(bool $skip)
+    {
+        $this->skipQuestion = $skip;
+        if ($skip) {
+            if ($this->defaultAnswerValue == null) {
+                throw new UnexpectedValueException("Requested to skip question without having set a default answer");
+            }
+            $this->setAnswer(Answer::create($this->defaultAnswerValue));
+        }
+    }
+
+    public function getSkipQuestion(): bool
+    {
+        return $this->skipQuestion;
     }
 
     /**

--- a/config/settings.php
+++ b/config/settings.php
@@ -1,7 +1,21 @@
 <?php
 
+$default_settings = [
+    "enabled_langauges" => [],
+    "enabled_surveys" => [],
+    "when_default_values" => [      # 'skip', 'ignore' or 'use'
+        "title" => "ignore",
+        "description" => "ignore",
+        "other" => "ignore"         # TODO: this is ignored for now, see FieldQuestionFactory class to enable
+    ]
+];
+
 if (file_exists(base_path('settings.json'))) {
     $settings = json_decode(file_get_contents(base_path('settings.json')), true);
+
+    # Merge with defaults
+    $settings = array_merge($default_settings, $settings);
+    $settings['when_default_values'] = array_merge($default_settings['when_default_values'], $settings['when_default_values']);
 }
 
-return $settings ?? [];
+return $settings ?? $default_settings;

--- a/settings.json
+++ b/settings.json
@@ -1,4 +1,8 @@
 {
     "enabled_languages": [],
-    "enabled_surveys": []
+    "enabled_surveys": [],
+    "when_default_values": {
+      "title": "ignore",
+      "description": "ignore"
+    }
 }


### PR DESCRIPTION
Implements the settings for default value handling as laid down in #96 .

It allows enabling the functionality for title and description, but leaves it commented out for handling of other fields. Before enabling it for such fields It would be necessary to check that the parsing of data types in this engine matches the way the API saves and provides default values.