### PR TITLE
feat: add language string customization #111

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,26 @@ Some important environment variables are:
 - `USHAHIDI_PLATFORM_API_TIMEOUT`:  Depending on your setup, you may want to set a custom timeout for requests to the Ushahidi Platform. It defaults to 2 seconds.
 - `USSD_MAX_CHARACTERS_PER_PAGE`: USSD messages are limited to a fixed amount of characters depending on the telecommunications service provider. This allows to paginate the content delivered to your users. It defaults to 160 characters.
 
+## Custom language strings
+If you would like to change any of the strings used by the bot, you may do so by providing a `lang_strings.json` file in the root of the project. The json file should have a key for each locale, and inside each locale a dictionary of keys to text. The keys would match the laravel structure of group.entry . For example:
+
+```
+{
+  "en": {
+    "conversation.selectSurvey": "Choose your adventure",
+    "conversation.thanksForSubmitting": "Good job!"
+  },
+  "es": {
+    "conversation.selectSurvey": "Elija su aventura",
+    "conversation.thanksForSubmitting": "¡Buen trabajo!"
+  }    
+}
+```
+
+This file would override the `selectSurvey` and `thanksforSubmitting` translations present in the [resources/lang/en/conversation.php](./resources/lang/en/conversation.php) and [resources/lang/es/conversation.php](./resources/lang/es/conversation.php) files.
+
+The file is loaded by the [CustomLangStringsProvider](./app/Providers/CustomLangStringsProvider.php) service.
+
 ## TODO
  - API Specification
  - Testing

--- a/app/Providers/CustomLangStringsProvider.php
+++ b/app/Providers/CustomLangStringsProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Loads custom language strings. This is used for selectively changing the messages offered to users.
+ * The strings are obtained from a JSON file at the root of the project named lang_strings.json
+ * 
+ * Expected format is:
+ * 
+ *   {
+ *     "en": {
+ *       "conversation.selectSurvey": "Choose your adventure"
+ *     },
+ *     "es": {
+ *       "conversation.selectSurvey": "Elija su aventura"
+ *     }
+ *   }
+ */
+class CustomLangStringsProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        if (file_exists(base_path('lang_strings.json'))) {
+            $lang_strings = json_decode(file_get_contents(base_path('lang_strings.json')), true);
+
+            if (is_null($lang_strings)) {
+                // Parsing error
+                Log::warning('Error loading custom language strings', ['parser_error' => json_last_error_msg()]);
+                return;
+            }
+
+            foreach ($lang_strings as $locale => $lines) {
+                // We need to pre-load the affected locales+groups, because otherwise the Translator
+                // may consider the groups already loaded and not look into the main files.
+                // This would have the effect of hiding strings that are NOT provided in the custom files.
+                $this->preloadForLines($locale, $lines);
+
+                // Add custom lines from file
+                app('translator')->addLines($lines, $locale);
+            }
+        }
+    }
+
+    private function preloadForLines($locale, $lines)
+    {
+        $keys = array_keys($lines);
+        $groups = array_unique(array_map(fn($x) => explode('.', $x)[0], $keys));
+        foreach ($groups as $group) {
+            app('translator')->load('*', $group, $locale);
+        }
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -161,6 +161,7 @@ return [
         App\Providers\RouteServiceProvider::class,
         App\Providers\BotMan\DriverServiceProvider::class,
         App\Providers\PlatformSDKProvider::class,
+        App\Providers\CustomLangStringsProvider::class,
     ],
 
     /*


### PR DESCRIPTION
Fixes #111 - allowing to customize the text sent to the user depending on deployment necessities.